### PR TITLE
Adding Dockerfile and Readme Update

### DIFF
--- a/Docker FIle
+++ b/Docker FIle
@@ -1,0 +1,23 @@
+#Deriving the latest base image
+FROM python:latest
+
+
+#Labels as key value pair
+LABEL Maintainer="gmazrael"
+
+# Any working directory can be chosen as per choice like '/' or '/home' etc
+# i have chosen /usr/app/src
+WORKDIR /usr/app/src
+
+#to COPY the remote file at working directory in container
+COPY requirements.txt ./
+COPY config.ini ./
+COPY anime_season_for_sonarr.py ./
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+
+#CMD instruction should be used to run the software
+#contained by your image, along with any arguments.
+
+CMD [ "python", "anime_season_for_sonarr.py $YEAR $SEASON"]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ Note: the config file is assumed to be located inside the directory you are runn
 # Additional info
 - Use --log to create a log file inside the working directory. It will contain the anime failed to be found.
 
+# Docker File
+- A Docker file is added to the repository for easy of running. To build the container as anime-sonarr Version 0.0.1:
+``` 
+docker image build -t anime-sonarr:0.0.1 ./
+```
+Any time you update the config file, you need to increment the version tag and run build again.
+To run an interactive shell within the image, run the following with the latest version tag:
+
+```
+docker run -it anime-sonarr:0.0.1
+```
+Once you are in the container, you can run the following to test:
+```
+python anime_season_for_sonarr.py 2024 Fall
+```
+
+
 # Credits
 This product uses the TMDB API but is not endorsed or certified by TMDB.
 


### PR DESCRIPTION
To allow for those who are running inside a container based workflow. Instead of worrying about python versions in their host, this provides them an immutable way to run. 

Docker file is simple and allows folks to run the commands interactively. I have not gotten it to enable run-once functionality with environment variable, but it would be usefull. 